### PR TITLE
adding paprika chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Also known as chips in strange countries.  A global standard for crisp/chip packaging colours.
 
 * Light blue - Salt 'n' vingear
+* Blue - paprika
 * Green - Cheese 'n' onion
 * Brown - Beef (possibly with onion)
 * Yellow - Chicken


### PR DESCRIPTION
Blue is a common color for paprika crisps (or chips as we would say) in Belgium, for example, https://static.ahold.com/cmgtcontent/media//001667100/000/001667158_001_408156_708.jpg

Please consider diversity and local culture in your global standard.

Cheers,
Wouter